### PR TITLE
Blueprint misses a comma

### DIFF
--- a/blueprints/ember-token-auth/index.js
+++ b/blueprints/ember-token-auth/index.js
@@ -3,7 +3,7 @@ module.exports = {
 
   afterInstall: function() {
     return this.addPackageToProject('ember-oauth2', '2.0.2-beta');
-  }
+  },
 
   afterUninstall: function() {
     return this.removePackageFromProject('ember-oauth2');

--- a/bower.json
+++ b/bower.json
@@ -36,8 +36,5 @@
   "dependencies": {
     "ember": "~2.8.0",
     "ember-cli-shims": "0.1.1"
-  },
-  "resolutions": {
-    "ember": "^2.1.0"
   }
 }


### PR DESCRIPTION
This breaks running the generator.

```
$ ember generate ember-token-auth                                                                                   new_oauth_flow [512b998] modified
Unexpected identifier
SyntaxError: Unexpected identifier
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:387:25)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:20:19)
    at Function.Blueprint.load (/Users/jan/Documents/projects/novation/circuit-librarian/frontend/node_modules/ember-cli/lib/models/blueprint.js:1276:29)
    at Function.Blueprint.lookup (/Users/jan/Documents/projects/novation/circuit-librarian/frontend/node_modules/ember-cli/lib/models/blueprint.js:1253:24)
    at CoreObject.module.exports [as beforeRun] (/Users/jan/Documents/projects/novation/circuit-librarian/frontend/node_modules/ember-cli/lib/utilities/merge-blueprint-options.js:24:27)
```

Additionally, bower.json contained a weird "resolutions" part that doesn't make any sense, I think.